### PR TITLE
setup.py: Don't install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	author_email="info@skelsecprojects.com",
 
 	# Packages
-	packages=find_packages(),
+	packages=find_packages(exclude=["tests", "tests.*"]),
 
 	# Include additional files into the package
 	include_package_data=True,


### PR DESCRIPTION
Downstreams generally want to be able to run the tests (so having them in the dist tarball is useful) but installing them isn't really necessary.